### PR TITLE
Move require rake from gemspec to lib/activeadmin-xls.rb

### DIFF
--- a/activeadmin-xls.gemspec
+++ b/activeadmin-xls.gemspec
@@ -1,5 +1,5 @@
-require 'rake'
 require File.expand_path('../lib/active_admin/xls/version', __FILE__)
+
 Gem::Specification.new do |s|
   s.name        = 'activeadmin-xls'
   s.version     = ActiveAdmin::Xls::VERSION

--- a/lib/activeadmin-xls.rb
+++ b/lib/activeadmin-xls.rb
@@ -1,3 +1,4 @@
+require 'rake'
 require 'active_admin'
 
 require 'active_admin/xls/version'


### PR DESCRIPTION
When running `bundle` especially in a CI environment, requiring a library inside the gemspec will usually cause trouble. This is the case when `rake` is required inside the gemspec. The CI initially doesn't have `rake` installed hence the require is failing.

This moves the require from the gemspec to the the `lib/activeadmin-xls.rb` to fix this scenario.