### PR TITLE
Modified active admin dependency to allow ~> 2

### DIFF
--- a/activeadmin-xls.gemspec
+++ b/activeadmin-xls.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.files = git_tracked_files - gem_ignored_files
 
-  s.add_runtime_dependency 'activeadmin', '>= 1.0.0', '< 2'
+  s.add_runtime_dependency 'activeadmin', '>= 1.0.0', '~> 2'
   s.add_runtime_dependency 'spreadsheet', '~> 1.0'
 
   s.required_ruby_version = '>= 2.0.0'


### PR DESCRIPTION
Current activeadmin version is 2.1.0, just allowed it. Didn't reproduced any issue.
Cheers.