### PR TITLE
ignore test/ folder for gem building

### DIFF
--- a/activeadmin-xls.gemspec
+++ b/activeadmin-xls.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   git_tracked_files = `git ls-files`.split("\n").sort
   gem_ignored_files = `git ls-files -i -X .gemignore`.split("\n")
 
-  s.files = git_tracked_files - gem_ignored_files
+  s.files = (git_tracked_files - gem_ignored_files).reject { |f| f.match(%r{^(test|spec|features)/}) }
 
   s.add_runtime_dependency 'activeadmin', '>= 1.0.0'
   s.add_runtime_dependency 'spreadsheet', '~> 1.0'


### PR DESCRIPTION
When you build the gem, you add the files that will be download for all users. The test/ folder is useless for external application 😉 

I have made this change because you have deprecation warning in your tests and the result is that all user show this deprecation in our application 😢  : 

> DEPRECATION WARNING: Initialization autoloaded the constants ApplicationHelper, StructureHelper, 
> ActiveAdmin::ViewsHelper, DeviseHelper, ApplicationController, InheritedResources::Base, DeviseController, Devise::SessionsController, Devise::PasswordsController, Devise::UnlocksController, Devise::RegistrationsController, and Devise::ConfirmationsController.
> 
> Being able to do this is deprecated. Autoloading during initialization is going
> to be an error condition in future versions of Rails.
> 
> Reloading does not reboot the application, and therefore code executed during
> initialization does not run again. So, if you reload ApplicationHelper, for example,
> the expected changes won't be reflected in that stale Module object.
> 
> These autoloaded constants have been unloaded.
> 
> In order to autoload safely at boot time, please wrap your code in a reloader
> callback this way:
> 
>     Rails.application.reloader.to_prepare do
>       # Autoload classes and modules needed at boot time here.
>     end
> 
> That block runs when the application boots, and every time there is a reload.
> For historical reasons, it may run twice, so it has to be idempotent.
> 
> Check the "Autoloading and Reloading Constants" guide to learn more about how
> Rails autoloads and reloads.

After merge this pull request, can you please make a new version of your amazing gem ? 🙏   thanks ! 