### PR TITLE
Extend ActiveAdmin the before_load way instead of within the engines

### DIFF
--- a/lib/active_admin/xls/engine.rb
+++ b/lib/active_admin/xls/engine.rb
@@ -8,15 +8,6 @@ module ActiveAdmin
         if Mime::Type.lookup_by_extension(:xls).nil?
           Mime::Type.register 'application/vnd.ms-excel', :xls
         end
-
-        ActiveAdmin::Views::PaginatedCollection.add_format :xls
-
-        ActiveAdmin::ResourceDSL.send :include, ActiveAdmin::Xls::DSL
-        ActiveAdmin::Resource.send :include, ActiveAdmin::Xls::ResourceExtension
-        ActiveAdmin::ResourceController.send(
-          :prepend,
-          ActiveAdmin::Xls::ResourceControllerExtension
-        )
       end
     end
   end

--- a/lib/active_admin/xls/extensions.rb
+++ b/lib/active_admin/xls/extensions.rb
@@ -1,0 +1,14 @@
+ActiveAdmin.before_load do
+  require 'active_admin/xls/dsl'
+  require 'active_admin/xls/resource_extension'
+  require 'active_admin/xls/resource_controller_extension'
+
+  ActiveAdmin::Views::PaginatedCollection.add_format :xls
+
+  ActiveAdmin::ResourceDSL.send :include, ActiveAdmin::Xls::DSL
+  ActiveAdmin::Resource.send :include, ActiveAdmin::Xls::ResourceExtension
+  ActiveAdmin::ResourceController.send(
+    :prepend,
+    ActiveAdmin::Xls::ResourceControllerExtension
+  )
+end

--- a/lib/activeadmin-xls.rb
+++ b/lib/activeadmin-xls.rb
@@ -3,7 +3,5 @@ require 'active_admin'
 
 require 'active_admin/xls/version'
 require 'active_admin/xls/builder'
-require 'active_admin/xls/dsl'
-require 'active_admin/xls/resource_extension'
-require 'active_admin/xls/resource_controller_extension'
 require 'active_admin/xls/engine'
+require 'active_admin/xls/extensions'


### PR DESCRIPTION
Using the engine causes Rails deprecation warnings because of Autoloading

The PR attacks the same problem as #21 but the problem was not resolved.

The workaround here is to use ActiveAdmin.before_load system instead of the initializer, because `ActiveAdmin::ResourceController` autoloads a lot of stuff, wich is now deprecated during initialize phase.

Here are the traces that I had before this patch:

```
DEPRECATION WARNING: Initialization autoloaded the constants CampagneHelper, ApplicationHelper, StructureHelper, AnonymeHelper, ActiveAdmin::ViewsHelper, DeviseHelper, ApplicationController, and InheritedResources::Base.

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.

Reloading does not reboot the application, and therefore code executed during
initialization does not run again. So, if you reload CampagneHelper, for example,
the expected changes won't be reflected in that stale Module object.

These autoloaded constants have been unloaded.

In order to autoload safely at boot time, please wrap your code in a reloader
callback this way:

    Rails.application.reloader.to_prepare do
      # Autoload classes and modules needed at boot time here.
    end

```