### PR TITLE
Fix NameError: uninitialized constant InheritedResources::Base

### DIFF
--- a/lib/active_admin/xls/engine.rb
+++ b/lib/active_admin/xls/engine.rb
@@ -9,14 +9,17 @@ module ActiveAdmin
           Mime::Type.register 'application/vnd.ms-excel', :xls
         end
 
-        ActiveAdmin::Views::PaginatedCollection.add_format :xls
+        
+        ActiveAdmin.before_load do |_app|
+          ActiveAdmin::Views::PaginatedCollection.add_format :xls
 
-        ActiveAdmin::ResourceDSL.send :include, ActiveAdmin::Xls::DSL
-        ActiveAdmin::Resource.send :include, ActiveAdmin::Xls::ResourceExtension
-        ActiveAdmin::ResourceController.send(
-          :prepend,
-          ActiveAdmin::Xls::ResourceControllerExtension
-        )
+          ActiveAdmin::ResourceDSL.send :include, ActiveAdmin::Xls::DSL
+          ActiveAdmin::Resource.send :include, ActiveAdmin::Xls::ResourceExtension
+          ActiveAdmin::ResourceController.send(
+            :prepend,
+            ActiveAdmin::Xls::ResourceControllerExtension
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
I've tried the changes in the PR #23, but then, another error is raised:

`NameError: uninitialized constant ActiveAdmin::ResourceController`

Wrapping the calls inside an `ActiveAdmin.before_load` block solved the problem and this is used in the gem itself to load their own extensions:

https://github.com/activeadmin/activeadmin/blob/cecfcf5d24e109c911136229ece4ce4bb71d6821/lib/active_admin/batch_actions.rb#L2-L17

As a workaround, you can temporarily replace the gem initializer in your `config/application.rb` .

<details><summary>config/application.rb</summary>
<p>

```ruby
# config/application.rb

module YourModule
  class Application < Rails::Application
    # ...

    config.before_configuration do
      ActiveAdmin::Xls::Engine.initializer 'active_admin.xls.fix', group: :all, after: 'active_admin.xls' do |app|
        if Mime::Type.lookup_by_extension(:xls).nil?
          Mime::Type.register 'application/vnd.ms-excel', :xls
        end

        # start changes - wrap calls
        ActiveAdmin.before_load do |_app|
          ActiveAdmin::Views::PaginatedCollection.add_format :xls

          ActiveAdmin::ResourceDSL.send :include, ActiveAdmin::Xls::DSL
          ActiveAdmin::Resource.send :include, ActiveAdmin::Xls::ResourceExtension
          ActiveAdmin::ResourceController.send(
            :prepend,
            ActiveAdmin::Xls::ResourceControllerExtension
          )
        end
        # end changes - wrap calls
      end

      ActiveAdmin::Xls::Engine.initializers.reject! { |i| i.name == 'active_admin.xls' }
    end

    # ...
  end
end
```
</p>
</details> 